### PR TITLE
Fix "Can't use $exists with Moment" error with mongoose 4.7.9

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,5 +1,33 @@
 var util = require('util');
 
+/*!
+ * COPIED FROM MONGOOSE CODE BASE (lib/utils.js).
+ * 
+ * Shallow copies defaults into options.
+ *
+ * @param {Object} defaults
+ * @param {Object} options
+ * @return {Object} the merged object
+ * @api private
+ */
+
+function assignDefaults(defaults, options) {
+  var keys = Object.keys(defaults),
+      i = keys.length,
+      k;
+
+  options = options || {};
+
+  while (i--) {
+    k = keys[i];
+    if (!(k in options)) {
+      options[k] = defaults[k];
+    }
+  }
+
+  return options;
+};
+
 module.exports = function(mongoose){
 	var CastError   = mongoose.Error.CastError;
 	var SchemaTypes = mongoose.SchemaTypes;
@@ -89,7 +117,7 @@ module.exports = function(mongoose){
 		});
 	}
 
-	SchemaMoment.prototype.$conditionalHandlers = {
+	SchemaMoment.prototype.$conditionalHandlers = assignDefaults(SchemaType.prototype.$conditionalHandlers, {
 		'$all' : handleArray,
 		'$gt'  : handleSingle,
 		'$gte' : handleSingle,
@@ -98,7 +126,7 @@ module.exports = function(mongoose){
 		'$lte' : handleSingle,
 		'$ne'  : handleSingle,
 		'$nin' : handleArray
-	};
+	});
 
 
 	/**

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -40,7 +40,12 @@ module.exports = function(mongoose){
 	 */
 
 	SchemaMoment.prototype.checkRequired = function (value) {
-		return Moment.isMoment(value);
+		if (value == null) { // double equal (==) is used on purpose, do NOT modify
+			return false;
+		}
+
+		value = Moment.isMoment(value) ? value : new Moment(value);
+		return value.isValid();
 	};
 
 	/**


### PR DESCRIPTION
For more information check [issue mongoose#4937](https://github.com/Automattic/mongoose/issues/4937).

In this PR there is also another change which I applied more than a year ago I think for the `checkRequired` issue. The approach used differs a bit from the solution applied in this project, but I tried to consider also the case for [invalid moments](http://momentjs.com/docs/#/utilities/invalid/).